### PR TITLE
Fix notifications missing after CRUD

### DIFF
--- a/src/main/java/com/example/dorm/controller/ContractController.java
+++ b/src/main/java/com/example/dorm/controller/ContractController.java
@@ -60,7 +60,8 @@ public class ContractController {
     }
 
     @PostMapping
-    public String createContract(@Valid @ModelAttribute Contract contract, BindingResult result, Model model) {
+    public String createContract(@Valid @ModelAttribute Contract contract, BindingResult result, Model model,
+                                 org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
             model.addAttribute("rooms", roomService.getAllRooms());
             return "contracts/form";
@@ -72,6 +73,7 @@ public class ContractController {
         }
         try {
             contractService.createContract(contract);
+            redirectAttributes.addFlashAttribute("successMessage", "Tạo hợp đồng thành công");
             return "redirect:/contracts";
         } catch (Exception e) {
             model.addAttribute("errorMessage", "Lỗi khi lưu hợp đồng: " + e.getMessage());
@@ -115,7 +117,8 @@ public class ContractController {
     }
 
     @PostMapping("/{id}")
-    public String updateContract(@PathVariable("id") Long id, @Valid @ModelAttribute Contract contract, BindingResult result, Model model) {
+    public String updateContract(@PathVariable("id") Long id, @Valid @ModelAttribute Contract contract, BindingResult result, Model model,
+                                 org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
             model.addAttribute("rooms", roomService.getAllRooms());
             return "contracts/form";
@@ -127,6 +130,7 @@ public class ContractController {
         }
         try {
             contractService.updateContract(id, contract);
+            redirectAttributes.addFlashAttribute("successMessage", "Cập nhật hợp đồng thành công");
             return "redirect:/contracts";
         } catch (Exception e) {
             model.addAttribute("errorMessage", "Lỗi khi cập nhật hợp đồng: " + e.getMessage());
@@ -135,11 +139,13 @@ public class ContractController {
     }
 
     @GetMapping("/{id}/delete")
-    public String deleteContract(@PathVariable("id") Long id, Model model) {
+    public String deleteContract(@PathVariable("id") Long id, Model model,
+                                 org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             Optional<Contract> contractOptional = contractService.getContract(id);
             if (contractOptional.isPresent()) {
                 contractService.deleteContract(id);
+                redirectAttributes.addFlashAttribute("successMessage", "Xóa hợp đồng thành công");
                 return "redirect:/contracts";
             } else {
                 model.addAttribute("errorMessage", "Không tìm thấy hợp đồng với ID: " + id);

--- a/src/main/java/com/example/dorm/controller/FeeController.java
+++ b/src/main/java/com/example/dorm/controller/FeeController.java
@@ -59,7 +59,8 @@ public class FeeController {
     @PostMapping
     public String createFee(@RequestParam("amountInput") String amountInput,
                             @Valid @ModelAttribute Fee fee,
-                            BindingResult result, Model model) {
+                            BindingResult result, Model model,
+                            org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
             model.addAttribute("contracts", contractService.getAllContracts(org.springframework.data.domain.Pageable.unpaged()).getContent());
             return "fees/form";
@@ -67,6 +68,7 @@ public class FeeController {
         try {
             fee.setAmount(parseAmount(amountInput));
             feeService.createFee(fee);
+            redirectAttributes.addFlashAttribute("successMessage", "Tạo phí thành công");
             return "redirect:/fees";
         } catch (Exception e) {
             model.addAttribute("errorMessage", "Lỗi khi lưu phí: " + e.getMessage());
@@ -113,7 +115,8 @@ public class FeeController {
     public String updateFee(@PathVariable("id") Long id,
                             @RequestParam("amountInput") String amountInput,
                             @Valid @ModelAttribute Fee fee,
-                            BindingResult result, Model model) {
+                            BindingResult result, Model model,
+                            org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
             model.addAttribute("contracts", contractService.getAllContracts(org.springframework.data.domain.Pageable.unpaged()).getContent());
             return "fees/form";
@@ -121,6 +124,7 @@ public class FeeController {
         try {
             fee.setAmount(parseAmount(amountInput));
             feeService.updateFee(id, fee);
+            redirectAttributes.addFlashAttribute("successMessage", "Cập nhật phí thành công");
             return "redirect:/fees";
         } catch (Exception e) {
             model.addAttribute("errorMessage", "Lỗi khi cập nhật phí: " + e.getMessage());
@@ -137,11 +141,13 @@ public class FeeController {
     }
 
     @GetMapping("/{id}/delete")
-    public String deleteFee(@PathVariable("id") Long id, Model model) {
+    public String deleteFee(@PathVariable("id") Long id, Model model,
+                            org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             Optional<Fee> feeOptional = feeService.getFee(id);
             if (feeOptional.isPresent()) {
                 feeService.deleteFee(id);
+                redirectAttributes.addFlashAttribute("successMessage", "Xóa phí thành công");
                 return "redirect:/fees";
             } else {
                 model.addAttribute("errorMessage", "Không tìm thấy phí với ID: " + id);

--- a/src/main/java/com/example/dorm/controller/RoomController.java
+++ b/src/main/java/com/example/dorm/controller/RoomController.java
@@ -56,9 +56,11 @@ public class RoomController {
     }
 
     @PostMapping
-    public String createRoom(@ModelAttribute Room room, Model model) {
+    public String createRoom(@ModelAttribute Room room, Model model,
+                             org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             roomService.createRoom(room);
+            redirectAttributes.addFlashAttribute("successMessage", "Tạo phòng thành công");
             return "redirect:/rooms";
         } catch (Exception e) {
             model.addAttribute("errorMessage", "Lỗi khi tạo phòng: " + e.getMessage());
@@ -103,11 +105,13 @@ public class RoomController {
     }
 
     @PostMapping("/{id}")
-    public String updateRoom(@PathVariable("id") Long id, @ModelAttribute Room room, Model model) {
+    public String updateRoom(@PathVariable("id") Long id, @ModelAttribute Room room, Model model,
+                             org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             Optional<Room> roomOptional = roomService.getRoom(id);
             if (roomOptional.isPresent()) {
                 roomService.updateRoom(id, room);
+                redirectAttributes.addFlashAttribute("successMessage", "Cập nhật phòng thành công");
                 return "redirect:/rooms";
             } else {
                 model.addAttribute("errorMessage", "Không tìm thấy phòng với ID: " + id);
@@ -120,11 +124,13 @@ public class RoomController {
     }
 
     @GetMapping("/{id}/delete")
-    public String deleteRoom(@PathVariable("id") Long id, Model model) {
+    public String deleteRoom(@PathVariable("id") Long id, Model model,
+                             org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             Optional<Room> roomOptional = roomService.getRoom(id);
             if (roomOptional.isPresent()) {
                 roomService.deleteRoom(id);
+                redirectAttributes.addFlashAttribute("successMessage", "Xóa phòng thành công");
                 return "redirect:/rooms";
             } else {
                 model.addAttribute("errorMessage", "Không tìm thấy phòng với ID: " + id);

--- a/src/main/java/com/example/dorm/controller/StudentController.java
+++ b/src/main/java/com/example/dorm/controller/StudentController.java
@@ -71,7 +71,8 @@ public class StudentController {
             @RequestParam(value = "contractEndDate", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate contractEndDate,
             @RequestParam(value = "contractStatus", required = false) String contractStatus,
-            Model model) {
+            Model model,
+            org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             var saved = studentService.saveStudent(student);
             if (student.getRoom() != null && contractStartDate != null && contractEndDate != null) {
@@ -83,6 +84,7 @@ public class StudentController {
                 c.setStatus(contractStatus != null ? contractStatus : "ACTIVE");
                 contractService.createContract(c);
             }
+            redirectAttributes.addFlashAttribute("successMessage", "Tạo sinh viên thành công");
             return "redirect:/students";
         } catch (Exception e) {
             model.addAttribute("errorMessage", "Lỗi khi tạo sinh viên: " + e.getMessage());
@@ -126,12 +128,14 @@ public class StudentController {
     }
 
     @PostMapping("/{id}")
-    public String updateStudent(@PathVariable("id") Long id, @ModelAttribute Student student, Model model) {
+    public String updateStudent(@PathVariable("id") Long id, @ModelAttribute Student student, Model model,
+                               org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             Optional<Student> studentOptional = studentService.getStudent(id);
             if (studentOptional.isPresent()) {
                 student.setId(id);
                 studentService.saveStudent(student);
+                redirectAttributes.addFlashAttribute("successMessage", "Cập nhật sinh viên thành công");
                 return "redirect:/students";
             } else {
                 model.addAttribute("errorMessage", "Không tìm thấy sinh viên với ID: " + id);
@@ -144,11 +148,13 @@ public class StudentController {
     }
 
     @GetMapping("/{id}/delete")
-    public String deleteStudent(@PathVariable("id") Long id, Model model) {
+    public String deleteStudent(@PathVariable("id") Long id, Model model,
+                               org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
         try {
             Optional<Student> studentOptional = studentService.getStudent(id);
             if (studentOptional.isPresent()) {
                 studentService.deleteStudent(id);
+                redirectAttributes.addFlashAttribute("successMessage", "Xóa sinh viên thành công");
                 return "redirect:/students";
             } else {
                 model.addAttribute("errorMessage", "Không tìm thấy sinh viên với ID: " + id);

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -508,3 +508,17 @@ h2 {
     background-color: var(--primary-color);
     color: #fff;
 }
+
+/* ======== NOTIFICATIONS ======== */
+.notification {
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-sm);
+    margin-bottom: 1rem;
+    color: #fff;
+}
+.notification.success {
+    background-color: var(--success-color);
+}
+.notification.error {
+    background-color: var(--danger-color);
+}

--- a/src/main/resources/templates/contracts/list.html
+++ b/src/main/resources/templates/contracts/list.html
@@ -11,6 +11,7 @@
     <div th:replace="fragments/sidebar :: sidebar"></div>
     <div class="content-with-sidebar">
         <div class="container">
+        <div th:replace="fragments/notifications :: notifications"></div>
         <h2>Danh Sách Hợp Đồng</h2>
         <div class="search-container">
             <form th:action="@{/contracts}" method="get">

--- a/src/main/resources/templates/fees/list.html
+++ b/src/main/resources/templates/fees/list.html
@@ -11,6 +11,7 @@
     <div th:replace="fragments/sidebar :: sidebar"></div>
     <div class="content-with-sidebar">
         <div class="container">
+        <div th:replace="fragments/notifications :: notifications"></div>
         <h2>Danh Sách Phí</h2>
         <div class="search-container">
             <form th:action="@{/fees}" method="get">

--- a/src/main/resources/templates/fragments/notifications.html
+++ b/src/main/resources/templates/fragments/notifications.html
@@ -1,0 +1,4 @@
+<div th:fragment="notifications">
+    <div class="notification success" th:if="${successMessage}" th:text="${successMessage}"></div>
+    <div class="notification error" th:if="${errorMessage}" th:text="${errorMessage}"></div>
+</div>

--- a/src/main/resources/templates/rooms/list.html
+++ b/src/main/resources/templates/rooms/list.html
@@ -11,6 +11,7 @@
     <div th:replace="fragments/sidebar :: sidebar"></div>
     <div class="content-with-sidebar">
         <div class="container">
+        <div th:replace="fragments/notifications :: notifications"></div>
         <h2>Danh Sách Phòng</h2>
         <div class="search-container">
             <form th:action="@{/rooms}" method="get">

--- a/src/main/resources/templates/students/list.html
+++ b/src/main/resources/templates/students/list.html
@@ -11,6 +11,7 @@
     <div th:replace="fragments/sidebar :: sidebar"></div>
     <div class="content-with-sidebar">
         <div class="container">
+        <div th:replace="fragments/notifications :: notifications"></div>
         <h2>Danh Sách Sinh Viên</h2>
         <div class="search-container">
             <form th:action="@{/students}" method="get">


### PR DESCRIPTION
## Summary
- add notification fragment and CSS styling
- include notification fragment in list pages
- flash success messages from controllers for create, update and delete

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*
- `./mvnw -q -DskipTests package` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685c1b78c338832db6983da10e79fde0